### PR TITLE
PS-8451 Update copyright.md and trademark-policy.md according to SEO naming rules (5.7)

### DIFF
--- a/docs/copyright-and-licensing-information.md
+++ b/docs/copyright-and-licensing-information.md
@@ -1,12 +1,12 @@
-# Copyright and Licensing Information
+# Copyright and licensing information
 
-## Documentation Licensing
+## Documentation licensing
 
 This software documentation is (C)2009-2022 Percona LLC and/or its affiliates
 and is distributed under the [Creative Commons Attribution-ShareAlike 2.0
 Generic](http://creativecommons.org/licenses/by-sa/2.0/) license.
 
-## Software License
+## Software license
 
 Percona Server is built upon MySQL from Oracle. Along with making our own
 modifications, we merge in changes from other sources such as community

--- a/docs/trademark-policy.md
+++ b/docs/trademark-policy.md
@@ -1,4 +1,4 @@
-# Trademark Policy
+# Trademark policy
 
 This Trademark Policy is to ensure that users of Percona-branded products or services know that what they receive has really been developed, approved, tested and maintained by Percona. Trademarks help to prevent confusion in the marketplace, by distinguishing one company’s or person’s products and services from another’s.
 


### PR DESCRIPTION
renamed:    docs/copyright.md -> docs/copyright-and-licensing-information.md
modified:   docs/trademark-policy.md