### PR TITLE
PS-8496 Fix links to copyright-and-licensing-information.md (5.7)

### DIFF
--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -258,7 +258,7 @@ nav:
       - trademark-policy.md
       - index_info_schema_tables.md
       - faq.md
-      - copyright.md
+      - copyright-and-licensing-information.md
       - glossary.md
 
 # - Version Selector: "../"


### PR DESCRIPTION
modified:   mkdocs-base.yml