### PR TITLE
Updated nav.html for 9.2 version of Material theme

### DIFF
--- a/_resource/overrides/partials/nav.html
+++ b/_resource/overrides/partials/nav.html
@@ -1,6 +1,7 @@
 {#-
   This file was automatically generated - do not edit
 -#}
+{% import "partials/nav-item.html" as item with context %}
 {% set class = "md-nav md-nav--primary" %}
 {% if "navigation.tabs" in features %}
   {% set class = class ~ " md-nav--lifted" %}
@@ -25,6 +26,7 @@
       {% set path = "__nav_" ~ loop.index %}
       {% set level = 1 %}
       {% include "partials/nav-item.html" %}
+      {{ item.render(nav_item, path, 1) }}
     {% endfor %}
     <br/>
    <label class="md-nav__title" for="__drawer">


### PR DESCRIPTION
Keep our customizations in place

modified: _resource/overrides/partials/nav.html