### PR TITLE
DOCS-98 Migrate form materialx to material.extensions (PS 5.7)

### DIFF
--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -81,8 +81,8 @@ markdown_extensions:
   pymdownx.inlinehilite: {}
   pymdownx.snippets: {}
   pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 plugins:
   search: 


### PR DESCRIPTION
modified: mkdocs-base.yml