### PR TITLE
PS-9267 Add CVE information to the PS 5.7.44-50 release notes

### DIFF
--- a/docs/installation/upgrade-third-party-lib.md
+++ b/docs/installation/upgrade-third-party-lib.md
@@ -1,0 +1,56 @@
+
+# Upgrade third-party libraries
+
+The following are generic instructions for updating libraries using a package manager. Your environment may differ. Upgrading libraries can have unintended consequences. Test the upgrade on a staging environment before upgrading production.
+
+## Prepare
+
+These steps apply to any package manager. The example updates the OpenSSL library.
+{.power-number}
+
+1. Create a full server backup to ensure data integrity in case of issues.
+2. Identify the library and review the installation method.
+3. Research the compatibility between the new library and your current MySQL version.
+4. Stop the server.
+
+## Upgrade
+
+=== "Distributions using the APT package manager"
+
+    Install the update:
+
+    ```{.bash data-prompt="$"}
+    $ sudo apt update
+    $ sudo apt install libssl-dev openssl
+    ```
+
+=== "Distributions using the YUM package manager"
+
+    Install the update:
+
+    ```{.bash data-prompt="$"}
+    $ sudo yum update
+    $ sudo yum install openssl
+    ```
+
+## Verify
+
+After the upgrade, do the following:
+{.power-number}
+
+1. Restart the server to ensure the library is loaded correctly.
+
+    ```{.bash data-prompt="$"}
+    $ sudo systemctl restart mysql
+    ```
+
+2. Connect to the server and verify the update with either `SHOW PLUGINS;` or `SHOW VARIABLES LIKE '%library_name%';`.
+
+3. Test the library functionality by running scripts or applications that rely on the upgraded library.
+
+## Troubleshoot
+
+If you find issues:
+
+* Check the error logs.
+* Consult the documentation for the library and online resources for any troubleshooting steps specific to this library. Look for any potential compatibility issues.

--- a/docs/release-notes/5.7.44-50.md
+++ b/docs/release-notes/5.7.44-50.md
@@ -6,6 +6,7 @@ This release is part of {{post}}. The fixes are available to [MySQL 5.7 Post-EOL
 
 Percona Server for MySQL 5.7.44-50 builds upon the functionality and bug fixes in MySQL 5.7.44 Community Edition. It adds enterprise-grade features and security enhancements developed by Percona.
 
+
 Percona Server for MySQL 5.7.44-50 contains the following fixes.
 
 ## Bug fixes
@@ -31,6 +32,19 @@ Percona Server for MySQL 5.7.44-50 contains the following fixes.
 * [PS-9092]: A high rate of page splits and merges in the past caused data inconsistencies.
 
 * [PS-9132]: After an unexpected server exit, persistent information about executed Global Transaction Identifiers (GTIDs) was lost during the `Gtid_state::save` operation.
+
+## Third-party fixes
+
+The following Common Vulnerabilities and Exposures (CVE) records have been identified in third-party libraries:
+
+| CVE            | Affected versions                                                |
+|----------------|------------------------------------------------------------------|
+| [CVE-2023-6129]  | OpenSSL versions 1.1.1 and 1.0.2 do not have this issue. If using OpenSSL 3.x.y, upgrade to 3.0.13, 3.1.5, or 3.2.1. |
+| [CVE-2024-0853]  | Version 8.5.0 is affected. Other versions are not. |
+
+We recommend that you [upgrade third-party libraries] to the latest version. 
+
+The operating system may port these fixes into the default version of the libraries installed in the systems.
 
 ## Useful links
 
@@ -68,3 +82,9 @@ For [training](https://www.percona.com/training), contact [Percona Training - St
 [PS-9092]: https://perconadev.atlassian.net/browse/PS-9092
 
 [PS-9132]: https://perconadev.atlassian.net/browse/PS-9132
+
+[CVE-2024-0853]: https://curl.se/docs/CVE-2024-0853.html
+
+[CVE-2023-6129]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-6129
+
+[upgrade third-party libraries]: ../installation/upgrade-third-party-lib.md

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -147,6 +147,7 @@ nav:
       - upgrade-repos.md
       - upgrade-standalone.md
       - upgrading_guide_56_57.md
+      - installation/upgrade-third-party-lib.md
   - Post-Installation:
       - installation/post-installation.md
   - Diagnostics Improvements:


### PR DESCRIPTION
 On branch ps-9267
	new file:   docs/installation/upgrade-third-party-lib.md
	modified:   docs/release-notes/5.7.44-50.md
	modified:   mkdocs-base.yml