### PR TITLE
Fix rocksdb_enable_ttl description

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1379,7 +1379,7 @@ The default value is `ON`.
 
 Specifies whether to keep expired TTL records during compaction.
 Enabled by default.
-If disabled, expired TTL records will be dropped during compaction.
+If disabled, expired TTL records will not be dropped during compaction.
 
 ### `rocksdb_enable_ttl_read_filtering`
 


### PR DESCRIPTION
I believe this description is backwards, both from the variable name, as well as the same setting described in MariaDB
https://typeoverflow.com/developer/docs/mariadb/myrocks-system-variables/index#rocksdb_enable_ttl