### PR TITLE
Fix formatting for Log Format section

### DIFF
--- a/docs/audit-log-plugin.md
+++ b/docs/audit-log-plugin.md
@@ -120,7 +120,7 @@ mysql> SHOW variables LIKE 'audit%';
 
 ## Log format
 
-The plugin supports the following log formats: `OLD`, `NEW`, `JSON`, and `CSV`. The `OLD\`\`format and the\`\`NEW` format are based on XML. The `OLD` format defines each log record with XML attributes. The `NEW` format defines each log record with XML tags. The information logged is the same for all four formats. The audit_log_format variable controls the log format choice.
+The plugin supports the following log formats: `OLD`, `NEW`, `JSON`, and `CSV`. The `OLD` format and the `NEW` format are based on XML. The `OLD` format defines each log record with XML attributes. The `NEW` format defines each log record with XML tags. The information logged is the same for all four formats. The audit_log_format variable controls the log format choice.
 
 ### Format examples
 


### PR DESCRIPTION
Fix an error in the log format section where ' ` ' was duplicated and caused a displaced highlighting.