### PR TITLE
PS-9639 [DOCS] - remove get-help label in Mkdocs 8.0

### DIFF
--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -145,7 +145,7 @@ extra:
 nav:
   - Home: index.md
   - psmysql-pro.md
-  - Get more help: get-help.md
+  - get-help.md
   - Release notes:
     - Release notes index: release-notes/release-notes_index.md
     - release-notes/8.0.40-31.md


### PR DESCRIPTION
	modified:   mkdocs-base.yml