### PR TITLE
Mention the server version the UUID_VX component has been added in

### DIFF
--- a/docs/uuid-versions.md
+++ b/docs/uuid-versions.md
@@ -1,6 +1,6 @@
 # UUID_VX component
 
-The `UUID_VX` component in Percona Server for MySQL provides functions to work with different versions of Universally Unique Identifiers (UUIDs). It allows for:
+The `UUID_VX` component in Percona Server for MySQL (available from v8.0.39-30) provides functions to work with different versions of Universally Unique Identifiers (UUIDs). It allows for:
 
 * Managing any UUID version: You can handle various UUID versions, including UUIDv1, UUIDv4, and others.  
 


### PR DESCRIPTION
As a way to help users and customers reading this part of the documentation understand that this is something that has been included only from a certain versions of PS for MySQL.