### PR TITLE
Function calls are using SET instead of SELECT

### DIFF
--- a/docs/audit-log-filter-variables.md
+++ b/docs/audit-log-filter-variables.md
@@ -285,7 +285,7 @@ This function returns either an `OK` for success or an error message for failure
 
 ```{.bash data-prompt="mysql>"}
 mysql> SET @filter = '{ "filter_name": { "log": true }}'
-mysql> SET audit_log_filter_set_filter('filter-name', @filter);
+mysql> SELECT audit_log_filter_set_filter('filter-name', @filter);
 ```
 
 ??? example "Expected output"

--- a/docs/audit-log-filter-variables.md
+++ b/docs/audit-log-filter-variables.md
@@ -284,7 +284,7 @@ This function returns either an `OK` for success or an error message for failure
 #### Example
 
 ```{.bash data-prompt="mysql>"}
-mysql> SET @filter = '{ "filter_name": { "log": true }}'
+mysql> SET @filter = '{ "filter": { "log": true }}'
 mysql> SELECT audit_log_filter_set_filter('filter-name', @filter);
 ```
 


### PR DESCRIPTION
I only found this bug but could be others:
```
mysql> SET audit_log_filter_set_filter('test', @filter);
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '('test', @filter)' at line 1
mysql> select audit_log_filter_set_filter('test', @filter);
+----------------------------------------------+
| audit_log_filter_set_filter('test', @filter) |
+----------------------------------------------+
| OK                                           |
+----------------------------------------------+
1 row in set (0.01 sec)
```
BTW, I found this on the 8.4 version too