### PR TITLE
Fix curl command

### DIFF
--- a/docs/upgrade-percona-repos.md
+++ b/docs/upgrade-percona-repos.md
@@ -30,7 +30,7 @@ Find the instructions on how to enable the repositories in the following documen
         ```{.bash data-prompt="$"}
         $ sudo apt update
         $ sudo apt install curl
-        $ curl -0 https://repo.percona.com/apt/percona-release_latest.generic_all.deb 
+        $ curl -O https://repo.percona.com/apt/percona-release_latest.generic_all.deb 
         $ sudo apt install gnupg2 lsb-release ./percona-release_latest.generic_all.deb
         $ sudo apt update
         $ sudo percona-release setup  {{pkg}}


### PR DESCRIPTION
This pull request includes a minor fix in the `docs/upgrade-percona-repos.md` file. The change corrects the curl option from `-0` to `-O` to properly download the Percona repository package.