### PR TITLE
Update write-filter-definitions.md

### DIFF
--- a/docs/write-filter-definitions.md
+++ b/docs/write-filter-definitions.md
@@ -365,7 +365,7 @@ SELECT audit_log_filter_set_filter('log_all', '{ "filter": { "log": true } }');
 To assign a filter to specific users, use the `audit_log_filter_set_user()` function. This function takes three parameters: username, userhost, and filtername.
 
 ```sql
-SELECT audit_log_filter_set_user('%', '%', 'log_all');
+SELECT audit_log_filter_set_user('%', 'log_all');
 ```
 
 ### Example: Financial tracking filter


### PR DESCRIPTION
Fixing
mysql [localhost:8400] {msandbox} ((none)) > SELECT audit_log_filter_set_user('%', '%', 'log_all'); ERROR 1123 (HY000): Can't initialize function 'audit_log_filter_set_user'; Wrong argument list: audit_log_filter_set_user(user_name, filter_name)

To

SELECT audit_log_filter_set_user('%', 'log_all');

It will work

mysql [localhost:8400] {msandbox} ((none)) > SELECT audit_log_filter_set_user('%', 'log_all'); +-------------------------------------------+
| audit_log_filter_set_user('%', 'log_all') |
+-------------------------------------------+
| OK                                        |
+-------------------------------------------+
1 row in set (0.01 sec)