### PR TITLE
Update audit-log-plugin.md 8.0

### DIFF
--- a/docs/audit-log-plugin.md
+++ b/docs/audit-log-plugin.md
@@ -684,7 +684,7 @@ This variable is used to specify the filename that’s going to store the audit 
 | Data type      | String             |
 | Default value   | OFF                |
 
-When this variable is set to `ON` log file will be closed and reopened. This can be used for manual log rotation.
+When this variable is set to `ON` log file will be closed and reopened.
 
 ### `audit_log_buffer_size`
 


### PR DESCRIPTION
Remove the sentence that states the variable will cause rotation.
See [Audit log plugin documentation mentions that audit_log_flush can be used to rotate audit log files](https://perconadev.atlassian.net/browse/PS-10318)
Add deprecation warning