### PR TITLE
Add required step for Percona Server repository setup with dnf

### DIFF
--- a/docs/quickstart-dnf.md
+++ b/docs/quickstart-dnf.md
@@ -56,6 +56,7 @@ The "expected output" depends on the operating system. The following examples ar
 2. Use the `percona-release` tool to set up the repository for Percona Server for MySQL 8.0.
 
     ```{.bash data-prompt="$"}
+    $ echo "REPOSITORIES=\"tools\"" | sudo tee /etc/default/percona-release
     $ sudo percona-release setup ps-80
     ```
 

--- a/docs/quickstart-dnf.md
+++ b/docs/quickstart-dnf.md
@@ -56,7 +56,7 @@ The "expected output" depends on the operating system. The following examples ar
 2. Use the `percona-release` tool to set up the repository for Percona Server for MySQL 8.0.
 
     ```{.bash data-prompt="$"}
-    $ echo "REPOSITORIES=\"tools\"" | sudo tee /etc/default/percona-release
+    $ echo "REPOSITORIES=\"tools\"" | sudo tee -a /etc/default/percona-release
     $ sudo percona-release setup ps-80
     ```
 


### PR DESCRIPTION
When running the current installation procedure with `dnf`, setting up the Percona Server repository fails with the following error:

```
 $ sudo percona-release setup ps-80
* Disabling all Percona Repositories
* Enabling the Percona Server for MySQL 8.0 repository
ERROR: Selected product uses "ps-80 tools" repositories. But the "tools" repository is disabled
Add "tools" repository to REPOSITORIES="" variable in /etc/default/percona-release file and re-run the script
```

An additional step is required to successfully set up the Percona Server repository:

```
echo "REPOSITORIES=\"tools\"" | sudo tee -a /etc/default/percona-release
```