### PR TITLE
Update compile-percona-server.md

### DIFF
--- a/docs/compile-percona-server.md
+++ b/docs/compile-percona-server.md
@@ -23,7 +23,7 @@ to distribute the resulting work, you can generate a new source tarball
 (exactly the same way as we do for release):
 
 ```shell
-cmake .
+cmake . -DFORCE_INSOURCE_BUILD=1
 make dist
 ```
 


### PR DESCRIPTION
change the command `cmake .` to `cmake . -DFORCE_INSOURCE_BUILD=1`

The original command got the following error:
```
CMake Error at CMakeLists.txt:591 (MESSAGE):
  Please do not build in-source.  Out-of source builds are highly
  recommended: you can have multiple builds for the same source, and there is
  an easy way to do cleanup, simply remove the build directory (note that
  'make clean' or 'make distclean' does *not* work)

  You *can* force in-source build by invoking cmake with
  -DFORCE_INSOURCE_BUILD=1
```

`-DFORCE_INSOURCE_BUILD=1` is also how the `build-ps.sh` script execute cmake: https://github.com/percona/percona-server/blob/8.0/build-ps/percona-server-8.0_builder.sh#L293