### PR TITLE
PS-10895 [DOCS] - We shall document that coredumper is not supported for ARM64 platforms (9.7)

### DIFF
--- a/docs/libcoredumper.md
+++ b/docs/libcoredumper.md
@@ -6,6 +6,12 @@ A core dump file is the documented moment of a computer when either the computer
 The `libcoredumper` is a free and Open Source fork of `google-coredumper`,
 enhanced to work on newer Linux versions, and GCC and CLANG.
 
+!!! note "ARM64 not supported"
+
+    The libcoredumper is not supported on ARM64 (aarch64) platforms. Use
+    standard core dumps (for example, `core-file`) or kernel core handling if you need
+    crash dumps on ARM64.
+
 !!! tip "Need Help Interpreting Stack Traces?"
     [Percona Support :octicons-link-external-16:](https://www.percona.com/services/support) offers 
     expert debugging and performance analysis to help you understand 
@@ -13,7 +19,7 @@ enhanced to work on newer Linux versions, and GCC and CLANG.
 
 ### Enabling the `libcoredumper`
 
-Enable core dumps for troubleshooting purposes.
+Enable core dumps for troubleshooting purposes on supported platforms.
 
 To enable the `libcoredumper`, add the `coredumper` variable to the
 `mysqld` section of `my.cnf`. This variable is independent of the


### PR DESCRIPTION
Update libcoredumper.md