### PR TITLE
Update release notes for Percona Server 8.4.10-10

### DIFF
--- a/docs/release-notes/8.4.10-10.md
+++ b/docs/release-notes/8.4.10-10.md
@@ -136,6 +136,8 @@ This release addresses the following security vulnerabilities:
 
 ## Builds and packaging
 
+Percona Server for MySQL 8.4.10-10 adds support for Ubuntu 26.04.
+
 * Percona Server for MySQL releases include a mixture of PGO and non-PGO builds. Where Profile-Guided Optimization (PGO) is enabled, the compiler uses runtime profiling data from representative workloads to guide optimization, which can improve throughput and reduce latency compared with non-PGO builds.
 
 * See [Profile-Guided Optimization (PGO) and non-PGO builds](../pgo.md) for benefits, considerations, and which build you receive for your platform.


### PR DESCRIPTION
Added support for Ubuntu 26.04 and clarified PGO details.